### PR TITLE
add default templates for new issues and pull requests

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,17 @@
+## Expected Behavior
+
+
+## Actual Behavior
+
+
+## Steps to Reproduce the Problem
+
+  1.
+  1.
+  1.
+
+## Specifications
+
+  - Version:
+  - Platform:
+  - Subsystem:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+## Description of the change
+
+> Description here
+
+## Type of change
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+
+## Related issues
+
+> Fix [#1]() 
+
+## Checklists
+
+### Development
+
+- [ ] Lint rules pass locally
+- [ ] The code changed/added as part of this pull request has been covered with tests
+- [ ] All tests related to the changed code pass in development
+
+### Code review 
+
+- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
+- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
+- [ ] Changes have been reviewed by at least one other engineer
+- [ ] Issue from task tracker has a link to this pull request 


### PR DESCRIPTION
As recommended by [https://github.com/VantaInc/sdlc-templates/tree/master/.github](https://github.com/VantaInc/sdlc-templates/tree/master/.github) for SOC 2 best practices.